### PR TITLE
support pre-packed `Cmd` and `Pipeline` instance

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -27,6 +27,7 @@ pub struct Cmd {
     // Arg::Simple contains the offset that marks the end of the argument
     args: Vec<Arg<usize>>,
     cursor: Option<u64>,
+    // TOOLCHAIN CHANGE: Bool to reinterpret `data` as pre-packed command.
     is_packed: bool,
 }
 
@@ -342,6 +343,7 @@ impl Cmd {
     /// Returns the packed command as a byte vector.
     #[inline]
     pub fn get_packed_command(&self) -> Vec<u8> {
+        // TOOLCHAIN CHANGE: Handle pre-packed pipeline.
         if self.is_packed {
             self.data.clone()
         } else {
@@ -352,6 +354,7 @@ impl Cmd {
     }
 
     pub(crate) fn write_packed_command(&self, cmd: &mut Vec<u8>) {
+        // TOOLCHAIN CHANGE: Handle pre-packed pipeline.
         if self.is_packed {
             use std::io::Write;
             cmd.reserve(self.data.len());

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -27,6 +27,7 @@ pub struct Cmd {
     // Arg::Simple contains the offset that marks the end of the argument
     args: Vec<Arg<usize>>,
     cursor: Option<u64>,
+    is_packed: bool,
 }
 
 /// Represents a redis iterator.
@@ -281,6 +282,18 @@ impl Cmd {
             data: vec![],
             args: vec![],
             cursor: None,
+            is_packed: false,
+        }
+    }
+
+    /// Create a command with pre-packed data.
+    /// This is a Toolchain-specific addition.
+    pub fn with_packed_data(packed_data: Vec<u8>) -> Cmd {
+        Cmd {
+            data: packed_data,
+            args: vec![],
+            cursor: None,
+            is_packed: true,
         }
     }
 
@@ -329,13 +342,23 @@ impl Cmd {
     /// Returns the packed command as a byte vector.
     #[inline]
     pub fn get_packed_command(&self) -> Vec<u8> {
-        let mut cmd = Vec::new();
-        self.write_packed_command(&mut cmd);
-        cmd
+        if self.is_packed {
+            self.data.clone()
+        } else {
+            let mut cmd = Vec::new();
+            self.write_packed_command(&mut cmd);
+            cmd
+        }
     }
 
     pub(crate) fn write_packed_command(&self, cmd: &mut Vec<u8>) {
-        write_command_to_vec(cmd, self.args_iter(), self.cursor.unwrap_or(0))
+        if self.is_packed {
+            use std::io::Write;
+            cmd.reserve(self.data.len());
+            cmd.write_all(&*self.data).expect("write cmd");
+        } else {
+            write_command_to_vec(cmd, self.args_iter(), self.cursor.unwrap_or(0))
+        }
     }
 
     pub(crate) fn write_packed_command_preallocated(&self, cmd: &mut Vec<u8>) {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -11,6 +11,7 @@ pub struct Pipeline {
     commands: Vec<Cmd>,
     transaction_mode: bool,
     ignored_commands: HashSet<usize>,
+    packed_pipeline: Option<Vec<u8>>,
 }
 
 /// A pipeline allows you to send multiple commands in one go to the
@@ -47,6 +48,17 @@ impl Pipeline {
             commands: Vec::with_capacity(capacity),
             transaction_mode: false,
             ignored_commands: HashSet::new(),
+            packed_pipeline: None,
+        }
+    }
+
+    /// Creates a pipeline with pre-packed data.
+    pub fn with_packed_data(packed_pipeline: Vec<u8>) -> Pipeline {
+        Pipeline {
+            commands: vec![],
+            transaction_mode: false,
+            ignored_commands: HashSet::new(),
+            packed_pipeline: Some(packed_pipeline),
         }
     }
 
@@ -76,7 +88,14 @@ impl Pipeline {
 
     #[cfg(feature = "aio")]
     pub(crate) fn write_packed_pipeline(&self, out: &mut Vec<u8>) {
-        write_pipeline(out, &self.commands, self.transaction_mode)
+        match &self.packed_pipeline {
+            Some(p) => {
+                use std::io::Write;
+                out.reserve(p.len());
+                out.write_all(&*p).expect("write pipeline");
+            }
+            None => write_pipeline(out, &self.commands, self.transaction_mode),
+        }
     }
 
     fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -11,6 +11,7 @@ pub struct Pipeline {
     commands: Vec<Cmd>,
     transaction_mode: bool,
     ignored_commands: HashSet<usize>,
+    // TOOLCHAIN CHANGE: Pre-packed pipeline. If this is set, then other fields will be ignored.
     packed_pipeline: Option<Vec<u8>>,
 }
 
@@ -53,6 +54,7 @@ impl Pipeline {
     }
 
     /// Creates a pipeline with pre-packed data.
+    /// This is a Toolchain-specific addition.
     pub fn with_packed_data(packed_pipeline: Vec<u8>) -> Pipeline {
         Pipeline {
             commands: vec![],
@@ -88,6 +90,7 @@ impl Pipeline {
 
     #[cfg(feature = "aio")]
     pub(crate) fn write_packed_pipeline(&self, out: &mut Vec<u8>) {
+        // TOOLCHAIN CHANGE: Handle pre-packed pipeline.
         match &self.packed_pipeline {
             Some(p) => {
                 use std::io::Write;


### PR DESCRIPTION
Toolchain's internal async Redis client uses a MPMC channel to send requests to several async Tokio tasks that individually manage connections. Ownership of the request must be passed to the worker tasks. Thus, the async client pre-packs the data and writes the packed data into the channel. 

This PR allows those pre-packed requests to be provided to `redis::aio::ConnectionLike` implementations. The change intentionally is a hack that does not change the `redis::aio::ConnectionLike` trait.