### PR TITLE
add impl of `redis::aio::ConnectionLike` if boxed

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -598,6 +598,25 @@ where
     }
 }
 
+impl<C: ConnectionLike> ConnectionLike for Box<C> {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+        (**self).req_packed_command(cmd)
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a crate::Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> RedisFuture<'a, Vec<Value>> {
+        (**self).req_packed_commands(cmd, offset, count)
+    }
+
+    fn get_db(&self) -> i64 {
+        (**self).get_db()
+    }
+}
+
 // Senders which the result of a single request are sent through
 type PipelineOutput<O, E> = oneshot::Sender<Result<Vec<O>, E>>;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::{self, Write};
 use std::net::{self, TcpStream, ToSocketAddrs};
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 use std::path::PathBuf;
 use std::str::{from_utf8, FromStr};
 use std::time::Duration;


### PR DESCRIPTION
Add an implementation of `redis::aio::ConnectionLike` for boxed types that implement that trait.